### PR TITLE
Fixes default symlink behavior

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -6,7 +6,7 @@ class grafana::params {
   $version            = '1.8.1'
   $install_method     = 'archive'
   $install_dir        = '/opt'
-  $symlink            = false
+  $symlink            = true
   $grafana_user       = 'root'
   $grafana_group      = 'root'
   $datasources        = {

--- a/spec/classes/grafana_init_spec.rb
+++ b/spec/classes/grafana_init_spec.rb
@@ -42,6 +42,7 @@ describe 'grafana', :type => 'class' do
         let :params do
           {
             :install_method	=> 'archive',
+            :symlink        => false,
             :datasources    => datasources
           }
         end


### PR DESCRIPTION
Both the README.md and the comments in init.pp state that symink defaults to
true when the params.pp was setting this to false
