### PR TITLE
sort datasource keys for idempotence

### DIFF
--- a/templates/config.js.erb
+++ b/templates/config.js.erb
@@ -8,7 +8,7 @@ function (Settings) {
 
     // datasources, you can add multiple
     datasources: {
-      <%- @datasources.keys.each do |ds_name| -%>
+      <%- @datasources.keys.sort.each do |ds_name| -%>
         <%= "#{ds_name}: {" %>
         <%- @datasources[ds_name].keys.sort.each do |ds_attr| -%>
           <%- if ds_attr == 'default' or ds_attr == 'grafanaDB' -%>


### PR DESCRIPTION
I see on this line https://github.com/bfraser/puppet-grafana/blob/master/templates/config.js.erb#L13 a `.sort` being called. I assume this is to keep the order of the hash consistent so that writes to `config.js` are idempotent.

however, my Puppet Reports are full of these:

```
 datasources: {
+        graphite: {
+            default: true,
+            type: 'graphite',
+            url: 'https://graphite.example.com',
+        },
         elasticsearch: {
             grafanaDB: true,
             index: 'grafana-dash',
             type: 'elasticsearch',
             url: 'https://logstash.example.com:9200',
         },
-        graphite: {
-            default: true,
-            type: 'graphite',
-            url: 'https://graphite.example.com',
-        },
     },
```

```
     datasources: {
-        graphite: {
-            default: true,
-            type: 'graphite',
-            url: 'https://graphite.example.com',
-        },
         elasticsearch: {
             grafanaDB: true,
             index: 'grafana-dash',
             type: 'elasticsearch',
             url: 'https://logstash.example.com:9200',
         },
+        graphite: {
+            default: true,
+            type: 'graphite',
+            url: 'https://graphite.example.com',
+        },
     },
```

an additional `.sort` is required to sort the _datasources_ as well as the contents of each datasource.
