### PR TITLE
Remove vagrant-wrapper

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,5 +14,4 @@ group :development do
   gem "travis-lint"
   gem "beaker"
   gem "beaker-rspec"
-  gem "vagrant-wrapper"
 end


### PR DESCRIPTION
The vagrant-wrapper gem is not actually required for anything; if installed, it monkey patches Object and causes bundler to behave in strange ways, including saying that it is required when it is not. I recommend removing it from all Gemfiles and uninstalling it from your system.

We jokingly call it a virus of the rubygem world, spreading by means of pull requests :)
