### PR TITLE
Add a way to configure Grafana 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,64 @@ The Grafana module's primary class, `grafana`, guides the basic setup of Grafana
 
 Controls which method to use for installing Grafana. Valid options are: 'archive', 'docker' and 'package'. The default is 'package'. If you wish to use the 'docker' installation method, you will need to include the 'docker' class in your node's manifest / profile.
 
+#####`cfg_location`
+
+Configures the location to which the Grafana configuration is written. The default location is '/etc/grafana/grafana.ini'.
+
+#####`cfg`
+
+Manages the Grafana configuration file. Grafana comes with its own default settings in a different configuration file (/opt/grafana/current/conf/defaults.ini), therefore this module does not supply any defaults.
+
+This parameter only accepts a hash as its value. Keys with hashes as values will generate sections, any other values are just plain values. The example below will result in...
+
+```puppet
+    class { 'grafana':
+      cfg => {
+        app_mode => 'production',
+        server   => {
+          http_port     => 8080,
+        },
+        database => {
+          type          => 'sqlite3',
+          host          => '127.0.0.1:3306',
+          name          => 'grafana',
+          user          => 'root',
+          password      => '',
+        },
+        users    => {
+          allow_sign_up => false,
+        },
+      },
+    }
+```
+
+...the following Grafana configuration:
+
+```ini
+# This file is managed by Puppet, any changes will be overwritten
+
+app_mode = production
+
+[server]
+http_port = 8080
+
+[database]
+type = sqlite3
+host = 127.0.0.1:3306
+name = grafana
+user = root
+password =
+
+[users]
+allow_sign_up = false
+```
+
+Some minor notes:
+
+ - If you want empty values, just use an empty string.
+ - Keys that contains dots (like auth.google) need to be quoted.
+ - The order of the keys in this hash is the same as they will be written to the configuration file. So settings that do not fall under a section will have to come before any sections in the hash.
+
 ##Limitations
 
 This module has been tested on Ubuntu 14.04, using the 'docker' and 'package' installation methods. Other configurations should work with minimal, if any, additional effort.

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -3,4 +3,11 @@
 # This class is called from grafana
 #
 class grafana::config {
+
+  $cfg = $::grafana::cfg
+
+  file {  $::grafana::cfg_location:
+    ensure  => present,
+    content => template('grafana/config.ini.erb'),
+  }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -21,9 +21,15 @@ class grafana (
   $package_source = $::grafana::params::package_source,
   $service_name   = $::grafana::params::service_name,
   $version        = $::grafana::params::version,
+
+  $cfg_location   = $::grafana::params::cfg_location,
+  $cfg            = $::grafana::params::cfg,
 ) inherits grafana::params {
 
   # validate parameters here
+  if !is_hash($cfg) {
+    fail('cfg parameter must be a hash')
+  }
 
   class { 'grafana::install': } ->
   class { 'grafana::config': } ~>
@@ -31,6 +37,6 @@ class grafana (
 
   contain 'grafana::install'
   contain 'grafana::service'
-  
+
   #Class['grafana']
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -20,4 +20,7 @@ class grafana::params {
       fail("${::operatingsystem} not supported")
     }
   }
+
+  $cfg_location = '/etc/grafana/grafana.ini'
+  $cfg = {}
 }

--- a/spec/classes/example_spec.rb
+++ b/spec/classes/example_spec.rb
@@ -32,4 +32,62 @@ describe 'grafana' do
       it { expect { should contain_package('grafana') }.to raise_error(Puppet::Error, /Nexenta not supported/) }
     end
   end
+
+  context 'invalid parameters' do
+    context 'cfg' do
+      let(:facts) {{
+        :osfamily => 'Debian',
+      }}
+
+      describe 'should raise an error when cfg parameter is not a hash' do
+        let(:params) {{
+          :cfg => [],
+        }}
+
+        it { expect { should contain_package('grafana') }.to raise_error(Puppet::Error, /cfg parameter must be a hash/) }
+      end
+
+      describe 'should not raise an error when cfg parameter is a hash' do
+        let(:params) {{
+          :cfg => {},
+        }}
+
+        it { should contain_package('grafana') }
+      end
+    end
+  end
+
+  context 'configuration file' do
+    let(:facts) {{
+      :osfamily => 'Debian',
+    }}
+
+    describe 'should not contain any configuration when cfg param is empty' do
+      it { should contain_file('/etc/grafana/grafana.ini').with_content("# This file is managed by Puppet, any changes will be overwritten\n\n") }
+    end
+
+    describe 'should correctly transform cfg param entries to Grafana configuration' do
+      let(:params) {{
+        :cfg => {
+          'app_mode' => 'production',
+          'section' => {
+            'string' => 'production',
+            'number' => 8080,
+            'boolean' => false,
+            'empty' => '',
+          },
+        },
+      }}
+
+      expected = "# This file is managed by Puppet, any changes will be overwritten\n\n"\
+                 "app_mode = production\n\n"\
+                 "[section]\n"\
+                 "string = production\n"\
+                 "number = 8080\n"\
+                 "boolean = false\n"\
+                 "empty = \n"
+
+      it { should contain_file('/etc/grafana/grafana.ini').with_content(expected) }
+    end
+  end
 end

--- a/templates/config.ini.erb
+++ b/templates/config.ini.erb
@@ -1,0 +1,13 @@
+# This file is managed by Puppet, any changes will be overwritten
+
+<%- @cfg.each_pair do |key, value|
+  if value.is_a?(Hash) -%>
+
+[<%= key %>]
+    <%- value.each_pair do |key, value| -%>
+<%= key %> = <%= value %>
+    <%- end -%>
+  <%- else -%>
+<%= key %> = <%= value %>
+  <%- end
+end -%>


### PR DESCRIPTION
In a discussion with @bfraser, we decided to introduce a single
configuration hash parameter. This allows for any configuration option
to be set without relasing a new version (which would be necessary when
creating a parameter for each settings). So this allows for more
flexicility.

Also we decided on using no defaults, since Grafana has sane defaults
already. So adding our own defaults would only complicate things.