### PR TITLE
Added support for 2.X release

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -26,4 +26,12 @@ class grafana::params {
   $max_search_results = 100
   $symlink            = true
   $version            = '1.9.0'
+  $manage_repository  = false
+  $config_ini         = '/etc/grafana/grafana.ini'
+  $database_type      = 'sqlite3'
+  $database_host      = '127.0.0.1:3306'
+  $database_name      = 'grafana'
+  $database_user      = 'root'
+  $database_password  = ''
+
 }

--- a/manifests/repository.pp
+++ b/manifests/repository.pp
@@ -1,0 +1,14 @@
+class grafana::repository {
+
+  case $operatingsystem {
+    'RedHat', 'CentOS': {
+      fail('CentOS repository support must be implemented, please fix')
+    }
+    /^(Debian|Ubuntu)$/:{
+      include grafana::repository::debian
+    }
+    default: {
+      fail('Unsupported operating system repository')
+    }
+  }
+}

--- a/manifests/repository/debian.pp
+++ b/manifests/repository/debian.pp
@@ -1,0 +1,12 @@
+class grafana::repository::debian {
+
+  apt::source { 'grafana':
+    location    => 'https://packagecloud.io/grafana/testing/debian/',
+    release     => 'wheezy',
+    repos       => 'main',
+    key         => 'D59097AB',
+    key_source  => 'https://packagecloud.io/gpg.key',
+    include_src => false,
+  }
+
+}

--- a/templates/grafana.ini.erb
+++ b/templates/grafana.ini.erb
@@ -1,0 +1,196 @@
+##################### Grafana Configuration Example #####################
+#
+# Everything has defaults so you only need to uncomment things you want to
+# change
+
+; app_mode = production
+
+#################################### Paths ####################################
+[paths]
+# Path to where grafana can store temp files, sessions, and the sqlite3 db (if that is useD)
+#
+;data = /var/lib/grafana
+#
+# Directory where grafana can store logs
+#
+;logs = /var/log/grafana
+
+#################################### Server ####################################
+[server]
+# Protocol (http or https)
+;protocol = http
+
+# The ip address to bind to, empty will bind to all interfaces
+;http_addr =
+
+# The http port  to use
+;http_port = 3000
+
+# The public facing domain name used to access grafana from a browser
+;domain = localhost
+
+# The full public facing url
+;root_url = %(protocol)s://%(domain)s:%(http_port)s/
+
+# Log web requests
+;router_logging = false
+
+# the path relative working path
+;static_root_path = public
+
+# enable gzip
+;enable_gzip = false
+
+# https certs & key file
+;cert_file =
+;cert_key =
+
+#################################### Database ####################################
+[database]
+# Either "mysql", "postgres" or "sqlite3", it's your choice
+type = <%= @database_type %>
+host = <%= @database_host %>
+name = <%= @database_name %>
+user = <%= @database_user %>
+password = <%= @database_password %>
+
+# For "postgres" only, either "disable", "require" or "verify-full"
+;ssl_mode = disable
+
+# For "sqlite3" only, path relative to data_path setting
+;path = grafana.db
+
+#################################### Session ####################################
+[session]
+# Either "memory", "file", "redis", "mysql", default is "memory"
+;provider = file
+
+# Provider config options
+# memory: not have any config yet
+# file: session dir path, is relative to grafana data_path
+# redis: config like redis server addr, poolSize, password, e.g. `127.0.0.1:6379,100,grafana`
+# mysql: go-sql-driver/mysql dsn config string, e.g. `user:password@tcp(127.0.0.1)/database_name`
+;provider_config = sessions
+
+# Session cookie name
+;cookie_name = grafana_sess
+
+# If you use session in https only, default is false
+;cookie_secure = false
+
+# Session life time, default is 86400
+;session_life_time = 86400
+
+#################################### Analytics ####################################
+[analytics]
+# Server reporting, sends usage counters to stats.grafana.org every 24 hours.
+# No ip addresses are being tracked, only simple counters to track
+# running instances, dashboard and error counts. It is very helpful to us.
+# Change this option to false to disable reporting.
+;reporting_enabled = true
+
+# Google Analytics universal tracking code, only enabled if you specify an id here
+;google_analytics_ua_id =
+
+#################################### Security ####################################
+[security]
+# default admin user, created on startup
+;admin_user = admin
+
+# default admin password, can be changed before first start of grafana,  or in profile settings
+;admin_password = admin
+
+# used for signing
+;secret_key = SW2YcwTIb9zpOOhoPsMm
+
+# Auto-login remember days
+;login_remember_days = 7
+;cookie_username = grafana_user
+;cookie_remember_name = grafana_remember
+
+#################################### Users ####################################
+[users]
+# disable user signup / registration
+;allow_sign_up = true
+
+# Allow non admin users to create organizations
+;allow_org_create = true
+
+# Set to true to automatically assign new users to the default organization (id 1)
+;auto_assign_org = true
+
+# Default role new users will be automatically assigned (if disabled above is set to true)
+;auto_assign_org_role = Viewer
+
+#################################### Anonymous Auth ##########################
+[auth.anonymous]
+# enable anonymous access
+;enabled = false
+
+# specify organization name that should be used for unauthenticated users
+;org_name = Main Org.
+
+# specify role for unauthenticated users
+;org_role = Viewer
+
+#################################### Github Auth ##########################
+[auth.github]
+;enabled = false
+;client_id = some_id
+;client_secret = some_secret
+;scopes = user:email
+;auth_url = https://github.com/login/oauth/authorize
+;token_url = https://github.com/login/oauth/access_token
+# Uncomment bellow to only allow specific email domains
+; allowed_domains = mycompany.com othercompany.com
+
+#################################### Google Auth ##########################
+[auth.google]
+;enabled = false
+;client_id = some_client_id
+;client_secret = some_client_secret
+;scopes = https://www.googleapis.com/auth/userinfo.profile https://www.googleapis.com/auth/userinfo.email
+;auth_url = https://accounts.google.com/o/oauth2/auth
+;token_url = https://accounts.google.com/o/oauth2/token
+# Uncomment bellow to only allow specific email domains
+; allowed_domains = mycompany.com othercompany.com
+
+#################################### Logging ##########################
+[log]
+# Either "console", "file", default is "console"
+# Use comma to separate multiple modes, e.g. "console, file"
+;mode = console, file
+
+# Buffer length of channel, keep it as it is if you don't know what it is.
+;buffer_len = 10000
+
+# Either "Trace", "Debug", "Info", "Warn", "Error", "Critical", default is "Trace"
+;level = Info
+
+# For "console" mode only
+[log.console]
+;level =
+
+# For "file" mode only
+[log.file]
+;level =
+# This enables automated log rotate(switch of following options), default is true
+;log_rotate = true
+
+# Max line number of single file, default is 1000000
+;max_lines = 1000000
+
+# Max size shift of single file, default is 28 means 1 << 28, 256MB
+;max_lines_shift = 28
+
+# Segment log daily, default is true
+;daily_rotate = true
+
+# Expired days of log file(delete after max days), default is 7
+;max_days = 7
+
+#################################### AMPQ Event Publisher ##########################
+[event_publisher]
+;enabled = false
+;rabbitmq_url = amqp://localhost/
+;exchange = grafana_events


### PR DESCRIPTION
Added version 2.X support. Ubuntu 14.04 only. Example params: 
class {'grafana':
  install_method => 'package',
  symlink => false,
  version => 'latest',
  manage_repository => true,
}