### PR TITLE
Sort config hashes to ensure that template output is determinstic.

### DIFF
--- a/templates/config.ini.erb
+++ b/templates/config.ini.erb
@@ -1,10 +1,10 @@
 # This file is managed by Puppet, any changes will be overwritten
 
-<%- @cfg.each_pair do |key, value|
+<%- @cfg.sort.each do |key, value|
   if value.is_a?(Hash) -%>
 
 [<%= key %>]
-    <%- value.each_pair do |key, value| -%>
+    <%- value.sort.each do |key, value| -%>
 <%= key %> = <%= value %>
     <%- end -%>
   <%- else -%>


### PR DESCRIPTION
The current behaviour results in the config.ini file randomly having its order change on each puppet run, for those on Ruby 1.8 (puppetmaster may need to be restarted to repro).

Sorting the hash resolves this issue, and the template will output consistently.