### PR TITLE
Support for mongodb + hiera

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,14 @@ Some minor notes:
  - Keys that contains dots (like auth.google) need to be quoted.
  - The order of the keys in this hash is the same as they will be written to the configuration file. So settings that do not fall under a section will have to come before any sections in the hash.
 
+Notes on MongoDb:
+The key's in MongoDb do not support dots.
+There for the following rule applies to configuration in hiera:
+
+- The dots in the keys, need to be replaced with a underscore.
+  Example: 'auth.google' is 'auth_google'
+
+
 #####`container_cfg`
 
 Boolean to control whether a configuration file should be generated when using the 'docker' install method. If 'true', use the 'cfg' and 'cfg_location' parameters to control creation of the file. Defaults to false.

--- a/templates/config.ini.erb
+++ b/templates/config.ini.erb
@@ -5,7 +5,7 @@
 
 [<%=
   case key
-    when "auth_anonymous" then "auth_anonymous"
+    when "auth_anonymous" then "auth.anonymous"
     when "auth_github"    then "auth.github"
     when "auth_google"    then "auth.google"
     else key

--- a/templates/config.ini.erb
+++ b/templates/config.ini.erb
@@ -5,10 +5,10 @@
 
 [<%=
   case key
-    when "auth_anonymouse" then 'auth.anonymouse'
-    when "auth_github"     then 'auth.github'
-    when "auth_google"     then 'auth.google'
-    else                        key
+    when "auth_anonymous" then "auth_anonymous"
+    when "auth_github"    then "auth.github"
+    when "auth_google"    then "auth.google"
+    else key
   end
 %>]
     <%- value.each_pair do |key, value| -%>

--- a/templates/config.ini.erb
+++ b/templates/config.ini.erb
@@ -3,7 +3,14 @@
 <%- @cfg.each_pair do |key, value|
   if value.is_a?(Hash) -%>
 
-[<%= key %>]
+[<%=
+  case key
+    when "auth_anonymouse" then 'auth.anonymouse'
+    when "auth_github"     then 'auth.github'
+    when "auth_google"     then 'auth.google'
+    else                        key
+  end
+%>]
     <%- value.each_pair do |key, value| -%>
 <%= key %> = <%= value %>
     <%- end -%>


### PR DESCRIPTION
Hi my setup is mongodb + hiera => puppet.
Mongodb does not support a dot in a key, the following is not allowed
"auth.anonymous" : {
    "enabled" : true
}

My suggestion is to use '_' as a replacement for '.' and use a case statement to catch the 3 anomalies in grafana.

An other solution can be to use: [<%= key.sub('_', '.') %>]
But this can lead to problems in the future problems due to updates.
And i want to make the problem visible.
