### PR TITLE
add 'repo' install method to fetch and install package directly from packagecloud

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -4,5 +4,6 @@ fixtures:
      archive: "git://github.com/camptocamp/puppet-archive.git"
      docker: "git://github.com/garethr/garethr-docker.git"
      wget: "git://github.com/maestrodev/puppet-wget.git"
+     apt: https://github.com/puppetlabs/puppetlabs-apt.git
   symlinks:
     grafana: "#{source_dir}"

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -1,1 +1,2 @@
 bfraser
+rplessl

--- a/README.md
+++ b/README.md
@@ -147,6 +147,10 @@ The installation directory to be used with the 'archive' install method. Default
 
 Controls which method to use for installing Grafana. Valid options are: 'archive', 'docker', 'repo' and 'package'. The default is 'package'. If you wish to use the 'docker' installation method, you will need to include the 'docker' class in your node's manifest / profile.
 
+####`manage_package_repo`
+
+If true this will setup the official grafana repositories on your host. Defaults to false.
+
 #####`package_name`
 
 The name of the package managed with the 'package' install method. Defaults to 'grafana'.

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ The installation directory to be used with the 'archive' install method. Default
 
 #####`install_method`
 
-Controls which method to use for installing Grafana. Valid options are: 'archive', 'docker' and 'package'. The default is 'package'. If you wish to use the 'docker' installation method, you will need to include the 'docker' class in your node's manifest / profile.
+Controls which method to use for installing Grafana. Valid options are: 'archive', 'docker', 'repo' and 'package'. The default is 'package'. If you wish to use the 'docker' installation method, you will need to include the 'docker' class in your node's manifest / profile.
 
 #####`package_name`
 

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -14,7 +14,7 @@ class grafana::config {
         }
       }
     }
-    'package': {
+    'package','repo': {
       $cfg = $::grafana::cfg
 
       file {  $::grafana::cfg_location:

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -34,7 +34,11 @@
 # Set to 'archive' to install Grafana using the tar archive.
 # Set to 'docker' to install Grafana using the official Docker container.
 # Set to 'package' to install Grafana using .deb or .rpm packages.
+# Set to 'repo' to install Grafana using an apt or yum repository.
 # Defaults to 'package'.
+#
+# [*manage_package_repo*]
+# If true this will setup the official grafana repositories on your host. Defaults to false.
 #
 # [*package_name*]
 # The name of the package managed with the 'package' install method.
@@ -59,22 +63,23 @@
 #  }
 #
 class grafana (
-  $archive_source   = "https://grafanarel.s3.amazonaws.com/builds/grafana-${version}.linux-x64.tar.gz",
-  $cfg_location     = $::grafana::params::cfg_location,
-  $cfg              = $::grafana::params::cfg,
-  $container_cfg    = $::grafana::params::container_cfg,
-  $container_params = $::grafana::params::container_params,
-  $data_dir         = $::grafana::params::data_dir,
-  $install_dir      = $::grafana::params::install_dir,
-  $install_method   = $::grafana::params::install_method,
-  $package_name     = $::grafana::params::package_name,
-  $package_source   = $::osfamily ? {
+  $archive_source      = "https://grafanarel.s3.amazonaws.com/builds/grafana-${version}.linux-x64.tar.gz",
+  $cfg_location        = $::grafana::params::cfg_location,
+  $cfg                 = $::grafana::params::cfg,
+  $container_cfg       = $::grafana::params::container_cfg,
+  $container_params    = $::grafana::params::container_params,
+  $data_dir            = $::grafana::params::data_dir,
+  $install_dir         = $::grafana::params::install_dir,
+  $install_method      = $::grafana::params::install_method,
+  $manage_package_repo = $::grafana::params::manage_package_repo,
+  $package_name        = $::grafana::params::package_name,
+  $package_source      = $::osfamily ? {
     'Debian'          => "https://grafanarel.s3.amazonaws.com/builds/grafana_${version}_amd64.deb",
     /(RedHat|Amazon)/ => "https://grafanarel.s3.amazonaws.com/builds/grafana-${version}-1.x86_64.rpm",
     default           => $::grafana::archive_source
   },
-  $service_name     = $::grafana::params::service_name,
-  $version          = $::grafana::params::version
+  $service_name        = $::grafana::params::service_name,
+  $version             = $::grafana::params::version
 ) inherits grafana::params {
 
   # validate parameters here

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -47,7 +47,7 @@ class grafana::install {
     'repo': {
       case $::osfamily {
         'Debian': {
-          if !defined(Class['apt']) {
+          if !defined( Class['apt'] ) {
             class { 'apt': }
           }
           apt::source { 'grafana':

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -19,7 +19,7 @@ class grafana::install {
             source      => $::grafana::package_source,
             destination => '/tmp/grafana.deb'
           }
-          
+
           package { $::grafana::package_name:
             ensure   => present,
             provider => 'dpkg',
@@ -42,6 +42,41 @@ class grafana::install {
         default: {
           fail("${::operatingsystem} not supported")
         }
+      }
+    }
+    'repo': {
+      case $::osfamily {
+        'Debian': {
+          if !defined(Class['apt']) {
+            class { 'apt': }
+          }
+          apt::source { 'grafana':
+            location    => 'https://packagecloud.io/grafana/stable/debian',
+            release     => 'wheezy',
+            repos       => 'main',
+            key         => 'E732A79A',
+            key_source  => 'https://packagecloud.io/gpg.key',
+            include_src => false,
+          }
+        }
+        'RedHat': {
+          yumrepo { 'grafana':
+            descr    => 'grafana repo',
+            baseurl  => 'https://packagecloud.io/grafana/stable/el/6/$basearch',
+            gpgcheck => 1,
+            gpgkey   => 'https://packagecloud.io/gpg.key https://grafanarel.s3.amazonaws.com/RPM-GPG-KEY-grafana',
+            enabled  => 1,
+          }
+        }
+        default: {
+          fail("${::operatingsystem} not supported")
+        }
+      }
+      package { 'libfontconfig':
+        ensure => present
+      }
+      package { 'grafana':
+        ensure => present
       }
     }
     'archive': {

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -56,12 +56,13 @@ class grafana::install {
               class { 'apt': }
             }
             apt::source { 'grafana':
-              location    => 'https://packagecloud.io/grafana/stable/debian',
-              release     => 'wheezy',
-              repos       => 'main',
-              key         => 'D59097AB',
-              key_source  => 'https://packagecloud.io/gpg.key',
-              include_src => false,
+              location => 'https://packagecloud.io/grafana/stable/debian',
+              release  => 'wheezy',
+              repos    => 'main',
+              key      =>  {
+                'id'     => 'D59097AB',
+                'source' => 'https://packagecloud.io/gpg.key'
+              },
             }
           }
 

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -47,6 +47,10 @@ class grafana::install {
     'repo': {
       case $::osfamily {
         'Debian': {
+          package { 'libfontconfig1':
+            ensure => present
+          }
+
           if !defined( Class['apt'] ) {
             class { 'apt': }
           }
@@ -58,15 +62,18 @@ class grafana::install {
             key_source  => 'https://packagecloud.io/gpg.key',
             include_src => false,
           }
-          package { 'libfontconfig1':
-            ensure => present
-          }
+
+
           package { 'grafana':
             ensure  => present,
             require => Package['libfontconfig1']
           }
         }
         'RedHat': {
+          package { 'fontconfig':
+            ensure => present
+          }
+
           yumrepo { 'grafana':
             descr    => 'grafana repo',
             baseurl  => 'https://packagecloud.io/grafana/stable/el/6/$basearch',
@@ -74,9 +81,7 @@ class grafana::install {
             gpgkey   => 'https://packagecloud.io/gpg.key https://grafanarel.s3.amazonaws.com/RPM-GPG-KEY-grafana',
             enabled  => 1,
           }
-          package { 'fontconfig':
-            ensure => present
-          }
+
           package { 'grafana':
             ensure  => present,
             require => Package['fontconfig']

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -58,6 +58,13 @@ class grafana::install {
             key_source  => 'https://packagecloud.io/gpg.key',
             include_src => false,
           }
+          package { 'libfontconfig1':
+            ensure => present
+          }
+          package { 'grafana':
+            ensure  => present,
+            require => Package['libfontconfig1']
+          }
         }
         'RedHat': {
           yumrepo { 'grafana':
@@ -67,16 +74,17 @@ class grafana::install {
             gpgkey   => 'https://packagecloud.io/gpg.key https://grafanarel.s3.amazonaws.com/RPM-GPG-KEY-grafana',
             enabled  => 1,
           }
+          package { 'fontconfig':
+            ensure => present
+          }
+          package { 'grafana':
+            ensure  => present,
+            require => Package['fontconfig']
+          }
         }
         default: {
           fail("${::operatingsystem} not supported")
         }
-      }
-      package { 'libfontconfig1':
-        ensure => present
-      }
-      package { 'grafana':
-        ensure => present
       }
     }
     'archive': {

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -11,7 +11,7 @@ class grafana::install {
     'package': {
       case $::osfamily {
         'Debian': {
-          package { 'libfontconfig':
+          package { 'libfontconfig1':
             ensure => present
           }
 
@@ -24,7 +24,7 @@ class grafana::install {
             ensure   => present,
             provider => 'dpkg',
             source   => '/tmp/grafana.deb',
-            require  => [Wget::Fetch['grafana'],Package['libfontconfig']]
+            require  => [Wget::Fetch['grafana'],Package['libfontconfig1']]
           }
         }
         'RedHat': {
@@ -72,7 +72,7 @@ class grafana::install {
           fail("${::operatingsystem} not supported")
         }
       }
-      package { 'libfontconfig':
+      package { 'libfontconfig1':
         ensure => present
       }
       package { 'grafana':

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -51,7 +51,7 @@ class grafana::install {
             ensure => present
           }
 
-          if ($manage_package_repo){
+          if ( $::grafana::manage_package_repo ){
             if !defined( Class['apt'] ) {
               class { 'apt': }
             }
@@ -75,7 +75,7 @@ class grafana::install {
             ensure => present
           }
 
-          if ($manage_package_repo){
+          if ( $::grafana::manage_package_repo ){
             yumrepo { 'grafana':
               descr    => 'grafana repo',
               baseurl  => 'https://packagecloud.io/grafana/stable/el/6/$basearch',

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -51,18 +51,19 @@ class grafana::install {
             ensure => present
           }
 
-          if !defined( Class['apt'] ) {
-            class { 'apt': }
+          if ($manage_package_repo){
+            if !defined( Class['apt'] ) {
+              class { 'apt': }
+            }
+            apt::source { 'grafana':
+              location    => 'https://packagecloud.io/grafana/stable/debian',
+              release     => 'wheezy',
+              repos       => 'main',
+              key         => 'D59097AB',
+              key_source  => 'https://packagecloud.io/gpg.key',
+              include_src => false,
+            }
           }
-          apt::source { 'grafana':
-            location    => 'https://packagecloud.io/grafana/stable/debian',
-            release     => 'wheezy',
-            repos       => 'main',
-            key         => 'D59097AB',
-            key_source  => 'https://packagecloud.io/gpg.key',
-            include_src => false,
-          }
-
 
           package { 'grafana':
             ensure  => present,
@@ -74,12 +75,14 @@ class grafana::install {
             ensure => present
           }
 
-          yumrepo { 'grafana':
-            descr    => 'grafana repo',
-            baseurl  => 'https://packagecloud.io/grafana/stable/el/6/$basearch',
-            gpgcheck => 1,
-            gpgkey   => 'https://packagecloud.io/gpg.key https://grafanarel.s3.amazonaws.com/RPM-GPG-KEY-grafana',
-            enabled  => 1,
+          if ($manage_package_repo){
+            yumrepo { 'grafana':
+              descr    => 'grafana repo',
+              baseurl  => 'https://packagecloud.io/grafana/stable/el/6/$basearch',
+              gpgcheck => 1,
+              gpgkey   => 'https://packagecloud.io/gpg.key https://grafanarel.s3.amazonaws.com/RPM-GPG-KEY-grafana',
+              enabled  => 1,
+            }
           }
 
           package { 'grafana':

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -54,7 +54,7 @@ class grafana::install {
             location    => 'https://packagecloud.io/grafana/stable/debian',
             release     => 'wheezy',
             repos       => 'main',
-            key         => 'E732A79A',
+            key         => 'D59097AB',
             key_source  => 'https://packagecloud.io/gpg.key',
             include_src => false,
           }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -4,16 +4,17 @@
 # It sets variables according to platform
 #
 class grafana::params {
-  $cfg_location     = '/etc/grafana/grafana.ini'
-  $cfg              = {}
-  $container_cfg    = false
-  $container_params = {}
-  $data_dir         = '/var/lib/grafana'
-  $docker_image     = 'grafana/grafana:latest'
-  $docker_ports     = '3000:3000'
-  $install_dir      = '/usr/share/grafana'
-  $install_method   = 'package'
-  $package_name     = 'grafana'
-  $service_name     = 'grafana-server'
-  $version          = '2.0.2'
+  $cfg_location        = '/etc/grafana/grafana.ini'
+  $cfg                 = {}
+  $container_cfg       = false
+  $container_params    = {}
+  $data_dir            = '/var/lib/grafana'
+  $docker_image        = 'grafana/grafana:latest'
+  $docker_ports        = '3000:3000'
+  $install_dir         = '/usr/share/grafana'
+  $install_method      = 'package'
+  $manage_package_repo = false
+  $package_name        = 'grafana'
+  $service_name        = 'grafana-server'
+  $version             = '2.0.2'
 }

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -17,7 +17,7 @@ class grafana::service {
 
       create_resources(docker::run, $container, $defaults)
     }
-    'package': {
+    'package','repo': {
       service { $::grafana::service_name:
         ensure => running,
         enable => true

--- a/metadata.json
+++ b/metadata.json
@@ -57,6 +57,11 @@
     {
       "name": "puppetlabs-stdlib",
       "version_requirement": ">=3.2.0 <5.0.0"
+    },
+    {
+      "name": "puppetlabs-apt",
+      "version_requirement": ">=2.0.0 <3.0.0"
     }
+
   ]
 }

--- a/spec/classes/grafana_spec.rb
+++ b/spec/classes/grafana_spec.rb
@@ -79,7 +79,8 @@ describe 'grafana' do
 
     context 'debian' do
       let(:facts) {{
-        :osfamily => 'Debian'
+        :osfamily => 'Debian',
+        :lsbdistid => 'Ubuntu'
       }}
 
       describe 'install apt repo dependencies first' do

--- a/spec/classes/grafana_spec.rb
+++ b/spec/classes/grafana_spec.rb
@@ -77,10 +77,10 @@ describe 'grafana' do
         :osfamily => 'Debian'
       }}
 
-      describe 'apt repo dependencies first' do
-        it { should contain_class('apt') }
-        it { should contain_apt__source('grafana').with(:release => 'wheezy', :repos => 'main', :location => 'https://packagecloud.io/grafana/stable/debian') }
-      end
+      # describe 'install apt repo dependencies first' do
+      #   it { should contain_class('apt') }
+      #   it { should contain_apt__source('grafana').with(:release => 'wheezy', :repos => 'main', :location => 'https://packagecloud.io/grafana/stable/debian') }
+      #end
 
       describe 'install dependencies first' do
         it { should contain_package('libfontconfig1').with_ensure('present').that_comes_before('Package[grafana]') }
@@ -96,9 +96,9 @@ describe 'grafana' do
         :osfamily => 'RedHat'
       }}
 
-      describe 'yum repo dependencies first' do
-        it { should contain_yumrepo('grafana').with(:baseurl => 'https://packagecloud.io/grafana/stable/el/6/$basearch', :gpgkey => 'https://packagecloud.io/gpg.key https://grafanarel.s3.amazonaws.com/RPM-GPG-KEY-grafana', :enabled => 1) }
-      end
+      # describe 'yum repo dependencies first' do
+      #  it { should contain_yumrepo('grafana').with(:baseurl => 'https://packagecloud.io/grafana/stable/el/6/$basearch', :gpgkey => 'https://packagecloud.io/gpg.key https://grafanarel.s3.amazonaws.com/RPM-GPG-KEY-grafana', :enabled => 1) }
+      # end
 
       describe 'install dependencies first' do
         it { should contain_package('fontconfig').with_ensure('present').that_comes_before('Package[grafana]') }

--- a/spec/classes/grafana_spec.rb
+++ b/spec/classes/grafana_spec.rb
@@ -72,15 +72,20 @@ describe 'grafana' do
   end
 
   context 'repo install method' do
+    let(:params) {{
+      :install_method => 'repo',
+      :manage_package_repo => true
+    }}
+
     context 'debian' do
       let(:facts) {{
         :osfamily => 'Debian'
       }}
 
-      # describe 'install apt repo dependencies first' do
-      #   it { should contain_class('apt') }
-      #   it { should contain_apt__source('grafana').with(:release => 'wheezy', :repos => 'main', :location => 'https://packagecloud.io/grafana/stable/debian') }
-      #end
+      describe 'install apt repo dependencies first' do
+        it { should contain_class('apt') }
+        it { should contain_apt__source('grafana').with(:release => 'wheezy', :repos => 'main', :location => 'https://packagecloud.io/grafana/stable/debian') }
+      end
 
       describe 'install dependencies first' do
         it { should contain_package('libfontconfig1').with_ensure('present').that_comes_before('Package[grafana]') }
@@ -96,9 +101,9 @@ describe 'grafana' do
         :osfamily => 'RedHat'
       }}
 
-      # describe 'yum repo dependencies first' do
-      #  it { should contain_yumrepo('grafana').with(:baseurl => 'https://packagecloud.io/grafana/stable/el/6/$basearch', :gpgkey => 'https://packagecloud.io/gpg.key https://grafanarel.s3.amazonaws.com/RPM-GPG-KEY-grafana', :enabled => 1) }
-      # end
+      describe 'yum repo dependencies first' do
+        it { should contain_yumrepo('grafana').with(:baseurl => 'https://packagecloud.io/grafana/stable/el/6/$basearch', :gpgkey => 'https://packagecloud.io/gpg.key https://grafanarel.s3.amazonaws.com/RPM-GPG-KEY-grafana', :enabled => 1) }
+      end
 
       describe 'install dependencies first' do
         it { should contain_package('fontconfig').with_ensure('present').that_comes_before('Package[grafana]') }

--- a/spec/classes/grafana_spec.rb
+++ b/spec/classes/grafana_spec.rb
@@ -47,7 +47,7 @@ describe 'grafana' do
       end
 
       describe 'install dependencies first' do
-        it { should contain_package('libfontconfig').with_ensure('present').that_comes_before('Package[grafana]') }
+        it { should contain_package('libfontconfig1').with_ensure('present').that_comes_before('Package[grafana]') }
       end
 
       describe 'install the package' do
@@ -83,7 +83,7 @@ describe 'grafana' do
       end
 
       describe 'install dependencies first' do
-        it { should contain_package('libfontconfig').with_ensure('present').that_comes_before('Package[grafana]') }
+        it { should contain_package('libfontconfig1').with_ensure('present').that_comes_before('Package[grafana]') }
       end
 
       describe 'install the package' do

--- a/spec/classes/grafana_spec.rb
+++ b/spec/classes/grafana_spec.rb
@@ -38,7 +38,7 @@ describe 'grafana' do
       let(:facts) {{
         :osfamily => 'Debian'
       }}
-      
+
       download_location = '/tmp/grafana.deb'
 
       describe 'use wget to fetch the package to a temporary location' do
@@ -67,6 +67,45 @@ describe 'grafana' do
 
       describe 'install the package' do
         it { should contain_package('grafana').with_provider('rpm') }
+      end
+    end
+  end
+
+  context 'repo install method' do
+    context 'debian' do
+      let(:facts) {{
+        :osfamily => 'Debian'
+      }}
+
+      describe 'apt repo dependencies first' do
+        it { should contain_class('apt') }
+        it { should contain_apt__source('grafana').with(:release => 'wheezy', :repos => 'main', :location => 'https://packagecloud.io/grafana/stable/debian') }
+      end
+
+      describe 'install dependencies first' do
+        it { should contain_package('libfontconfig').with_ensure('present').that_comes_before('Package[grafana]') }
+      end
+
+      describe 'install the package' do
+        it { should contain_package('grafana').with_ensure('present') }
+      end
+    end
+
+    context 'redhat' do
+      let(:facts) {{
+        :osfamily => 'RedHat'
+      }}
+
+      describe 'yum repo dependencies first' do
+        it { should contain_yumrepo('grafana').with(:baseurl => 'https://packagecloud.io/grafana/stable/el/6/$basearch', :gpgkey => 'https://packagecloud.io/gpg.key https://grafanarel.s3.amazonaws.com/RPM-GPG-KEY-grafana', :enabled => 1) }
+      end
+
+      describe 'install dependencies first' do
+        it { should contain_package('fontconfig').with_ensure('present').that_comes_before('Package[grafana]') }
+      end
+
+      describe 'install the package' do
+        it { should contain_package('grafana').with_ensure('present') }
       end
     end
   end


### PR DESCRIPTION
This add's an additional install method 'repo' which includes the packagecloud repositories for install and update grafana. Enhanced for Debian/Ubuntu and RedHat.

Also fix package name of libfontconfig to libfontconfig1 which is the correct one on Ubuntu LTS. This fixes the reinstallation of libfontconfig each time the puppet runs.

spec file is enhanced, but needs a review from a more experienced spec file writer.