### PR TITLE
Set the owner permissions for config files

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -11,6 +11,9 @@ class grafana::config {
         file {  $::grafana::cfg_location:
           ensure  => present,
           content => template('grafana/config.ini.erb'),
+          owner   => 'root',
+          group   => 'grafana',
+          mode    => '0440',
         }
       }
     }
@@ -20,6 +23,9 @@ class grafana::config {
       file {  $::grafana::cfg_location:
         ensure  => present,
         content => template('grafana/config.ini.erb'),
+        owner   => 'root',
+        group   => 'grafana',
+        mode    => '0440',
       }
     }
     'archive': {
@@ -28,6 +34,9 @@ class grafana::config {
       file { "${::grafana::install_dir}/conf/custom.ini":
         ensure  => present,
         content => template('grafana/config.ini.erb'),
+        owner   => 'root',
+        group   => 'grafana',
+        mode    => '0440',
       }
     }
     default: {
@@ -40,6 +49,9 @@ class grafana::config {
     file { '/etc/grafana/ldap.toml':
       ensure  => present,
       content => inline_template("<%= require 'toml'; TOML::Generator.new(@ldap_cfg).body %>\n"),
+      owner   => 'root',
+      group   => 'grafana',
+      mode    => '0440',
     }
   }
 }

--- a/spec/classes/grafana_spec.rb
+++ b/spec/classes/grafana_spec.rb
@@ -237,6 +237,13 @@ describe 'grafana' do
     describe 'should not contain any configuration when cfg param is empty' do
       it { should contain_file('/etc/grafana/grafana.ini').with_content("# This file is managed by Puppet, any changes will be overwritten\n\n") }
     end
+    describe 'should have the correct ownership and permissions for config file' do
+      it { should contain_file('/etc/grafana/grafana.ini').with(
+          :owner => 'root',
+          :group => 'grafana',
+          :mode => '0440',
+      )}
+    end
 
     describe 'should correctly transform cfg param entries to Grafana configuration' do
       let(:params) {{
@@ -303,6 +310,13 @@ describe 'grafana' do
                        "\n"
 
       it { should contain_file('/etc/grafana/ldap.toml').with_content(ldap_expected) }
+      describe 'should have the correct ownership and permissions for ldap file' do
+        it { should contain_file('/etc/grafana/ldap.toml').with(
+            :owner => 'root',
+            :group => 'grafana',
+            :mode => '0440',
+        )}
+      end
     end
   end
 end


### PR DESCRIPTION
We should set the owner, group and mode for config files so that they don't expose the admin password or ldap credentials by default.