### PR TITLE
The module currently doensnt pass rake validate

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -3,7 +3,7 @@
   "version": "2.5.0",
   "author": "bfraser",
   "summary": "This module provides Grafana, a dashboard and graph editor for Graphite and InfluxDB.",
-  "license": "Apache 2.0",
+  "license": "Apache-2.0",
   "source": "git://github.com/bfraser/puppet-grafana.git",
   "project_page": "https://github.com/bfraser/puppet-grafana",
   "issues_url": "https://github.com/bfraser/puppet-grafana/issues",


### PR DESCRIPTION
rake validate currently errors with a Warning: License Indentifier Apache 2.0 is not in the SPDX list. message, adding a dash fixes this.