### PR TITLE
allow version 'installed' in case of a yum repo

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -90,7 +90,7 @@ class grafana::install {
           }
 
           package { $::grafana::package_name:
-            ensure  => "${::grafana::version}-${::grafana::rpm_iteration}",
+            ensure  => $::grafana::version,
             require => Package['fontconfig']
           }
         }

--- a/spec/classes/grafana_spec.rb
+++ b/spec/classes/grafana_spec.rb
@@ -111,7 +111,7 @@ describe 'grafana' do
       end
 
       describe 'install the package' do
-        it { should contain_package('grafana').with_ensure('2.5.0-1') }
+        it { should contain_package('grafana').with_ensure('2.5.0') }
       end
     end
   end


### PR DESCRIPTION
It should be possible to set the version to installed/latest/... in case of installation method 'repo' on a RedHat system.
With the current puppet code if the version 'installed' is used, it tries to install a package called 'package grafana-installed-1'.
