### PR TITLE
add parameter install_with_apt

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -37,6 +37,11 @@
 # Set to 'repo' to install Grafana using an apt or yum repository.
 # Defaults to 'package'.
 #
+# [*install_with_apt*]
+# Set to 'true' if you want to install the package via apt. The apt repository is NOT managed
+# by this module. You can use the puppetlabs-apt module for this task.
+# Defaults to false.
+#
 # [*manage_package_repo*]
 # If true this will setup the official grafana repositories on your host. Defaults to true.
 #
@@ -72,6 +77,7 @@ class grafana (
   $data_dir            = $::grafana::params::data_dir,
   $install_dir         = $::grafana::params::install_dir,
   $install_method      = $::grafana::params::install_method,
+  $install_with_apt    = $::grafana::params::install_with_apt,
   $manage_package_repo = $::grafana::params::manage_package_repo,
   $package_name        = $::grafana::params::package_name,
   $package_source      = $::osfamily ? {
@@ -88,6 +94,7 @@ class grafana (
   if !is_hash($cfg) {
     fail('cfg parameter must be a hash')
   }
+  validate_bool($install_with_apt)
 
   class { 'grafana::install': } ->
   class { 'grafana::config': } ~>

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -11,20 +11,28 @@ class grafana::install {
     'package': {
       case $::osfamily {
         'Debian': {
-          package { 'libfontconfig1':
-            ensure => present
+          if $::grafana::install_with_apt {
+            package { $::grafana::package_name:
+              ensure   => present,
+              provider => 'apt',
+            }
           }
+          else {
+            package { 'libfontconfig1':
+              ensure => present
+            }
 
-          wget::fetch { 'grafana':
-            source      => $::grafana::package_source,
-            destination => '/tmp/grafana.deb'
-          }
+            wget::fetch { 'grafana':
+              source      => $::grafana::package_source,
+              destination => '/tmp/grafana.deb'
+            }
 
-          package { $::grafana::package_name:
-            ensure   => present,
-            provider => 'dpkg',
-            source   => '/tmp/grafana.deb',
-            require  => [Wget::Fetch['grafana'],Package['libfontconfig1']]
+            package { $::grafana::package_name:
+              ensure   => present,
+              provider => 'dpkg',
+              source   => '/tmp/grafana.deb',
+              require  => [Wget::Fetch['grafana'],Package['libfontconfig1']]
+            }
           }
         }
         'RedHat': {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -13,6 +13,7 @@ class grafana::params {
   $docker_ports        = '3000:3000'
   $install_dir         = '/usr/share/grafana'
   $install_method      = 'package'
+  $install_with_apt    = false
   $ldap_cfg            = false
   $manage_package_repo = true
   $package_name        = 'grafana'

--- a/spec/classes/grafana_spec.rb
+++ b/spec/classes/grafana_spec.rb
@@ -32,9 +32,27 @@ describe 'grafana' do
   end
 
   context 'package install method' do
-    context 'debian' do
+
+    context 'debian apt' do
       let(:facts) {{
         :osfamily => 'Debian'
+      }}
+      let(:params) {{
+        :install_with_apt => true
+      }}
+
+      describe 'install the package with apt' do
+        it { should contain_package('grafana').with_provider('apt') }
+        it { should contain_package('grafana').with('ensure' => 'present') }
+      end
+    end
+
+    context 'debian dpkg' do
+      let(:facts) {{
+        :osfamily => 'Debian'
+      }}
+      let(:params) {{
+        :install_with_apt => false
       }}
 
       download_location = '/tmp/grafana.deb'


### PR DESCRIPTION
which defines if the package is installed with the apt provider. This gives
you the possibility to install the grafana package from the apt sources.
This is especially useful if you already manage apt repos with puppet, e.g.
with the puppetlabs-apt module.

The default value is set to false so it doesn't change the existent behaviour
of this module.