### PR TITLE
Autorequire service

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,9 +1,9 @@
 fixtures:
   repositories:
-     stdlib: "git://github.com/puppetlabs/puppetlabs-stdlib.git"
-     archive: "git://github.com/camptocamp/puppet-archive.git"
-     docker: "git://github.com/garethr/garethr-docker.git"
-     wget: "git://github.com/maestrodev/puppet-wget.git"
-     apt: https://github.com/puppetlabs/puppetlabs-apt.git
+     stdlib: "https://github.com/puppetlabs/puppetlabs-stdlib.git"
+     archive: "https://github.com/camptocamp/puppet-archive.git"
+     docker: "https://github.com/garethr/garethr-docker.git"
+     wget: "https://github.com/maestrodev/puppet-wget.git"
+     apt: "https://github.com/puppetlabs/puppetlabs-apt.git"
   symlinks:
     grafana: "#{source_dir}"

--- a/lib/puppet/type/grafana_dashboard.rb
+++ b/lib/puppet/type/grafana_dashboard.rb
@@ -72,4 +72,7 @@ Puppet::Type.newtype(:grafana_dashboard) do
     validate do
         fail('content is required when ensure is present') if self[:ensure] == :present and self[:content].nil?
     end
+    autorequire(:service) do
+      'grafana-server'
+    end
 end

--- a/lib/puppet/type/grafana_datasource.rb
+++ b/lib/puppet/type/grafana_datasource.rb
@@ -88,4 +88,7 @@ Puppet::Type.newtype(:grafana_datasource) do
             end
         end
     end
+    autorequire(:service) do
+      'grafana-server'
+    end
 end

--- a/metadata.json
+++ b/metadata.json
@@ -4,7 +4,7 @@
   "author": "bfraser",
   "summary": "This module provides Grafana, a dashboard and graph editor for Graphite and InfluxDB.",
   "license": "Apache 2.0",
-  "source": "git://github.com/bfraser/puppet-grafana.git",
+  "source": "https://github.com/bfraser/puppet-grafana.git",
   "project_page": "https://github.com/bfraser/puppet-grafana",
   "issues_url": "https://github.com/bfraser/puppet-grafana/issues",
   "tags": [


### PR DESCRIPTION
If a service grafana-server is present it doesn't really make sense
to manage a dashboard or a datasource before. Which might happen if
you don't specify explicit ordering. The autorequire automagically
takes care of that.