### PR TITLE
Switch to puppet/archive

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,7 +1,7 @@
 fixtures:
   repositories:
      stdlib: "git://github.com/puppetlabs/puppetlabs-stdlib.git"
-     archive: "git://github.com/camptocamp/puppet-archive.git"
+     archive: "git://github.com/puppet-community/puppet-archive.git"
      docker: "git://github.com/garethr/garethr-docker.git"
      wget: "git://github.com/maestrodev/puppet-wget.git"
      apt: https://github.com/puppetlabs/puppetlabs-apt.git

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ pkg
 spec/fixtures
 .rspec_system
 .vagrant
+log/
 
 # for a library or gem, you might want to ignore these files since the code is
 # intended to run in multiple environments; otherwise, check them in:

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -102,31 +102,32 @@ class grafana::install {
     'archive': {
       # create log directory /var/log/grafana (or parameterize)
 
-      archive { 'grafana':
-        ensure           => present,
-        checksum         => false,
-        root_dir         => 'public',
-        strip_components => 1,
-        target           => $::grafana::install_dir,
-        url              => $::grafana::archive_source
-      }
-
       if !defined(User['grafana']){
         user { 'grafana':
-          ensure  => present,
-          home    => $::grafana::install_dir,
-          require => Archive['grafana']
+          ensure => present,
+          home   => $::grafana::install_dir
         }
       }
 
       file { $::grafana::install_dir:
-        ensure       => directory,
-        group        => 'grafana',
-        owner        => 'grafana',
-        recurse      => true,
-        recurselimit => 3,
-        require      => User['grafana']
+        ensure  => directory,
+        group   => 'grafana',
+        owner   => 'grafana',
+        require => User['grafana']
       }
+
+      archive { '/tmp/grafana.tar.gz':
+        ensure          => present,
+        extract         => true,
+        extract_command => 'tar xfz %s --strip-components=1',
+        extract_path    => $::grafana::install_dir,
+        source          => $::grafana::archive_source,
+        user            => 'grafana',
+        group           => 'grafana',
+        cleanup         => true,
+        require         => File[$::grafana::install_dir]
+      }
+
     }
     default: {
       fail("Installation method ${::grafana::install_method} not supported")

--- a/metadata.json
+++ b/metadata.json
@@ -43,8 +43,8 @@
   ],
   "dependencies": [
     {
-      "name": "camptocamp/archive",
-      "version_requirement": ">= 0.3.2 <2.0.0"
+      "name": "puppet/archive",
+      "version_requirement": ">= 0.5.1"
     },
     {
       "name": "garethr/docker",

--- a/spec/classes/grafana_spec.rb
+++ b/spec/classes/grafana_spec.rb
@@ -148,12 +148,12 @@ describe 'grafana' do
 
     install_dir    = '/usr/share/grafana'
     service_config = '/usr/share/grafana/conf/custom.ini'
+    archive_source = 'https://grafanarel.s3.amazonaws.com/builds/grafana-2.5.0.linux-x64.tar.gz'
 
     describe 'extract archive to install_dir' do
-      it { should contain_archive('grafana').with_ensure('present') }
-      it { should contain_archive('grafana').with_target(install_dir) }
-      it { should contain_archive('grafana').with_strip_components(1) }
-      it { should contain_archive('grafana').that_comes_before('User[grafana]') }
+      it { should contain_archive('/tmp/grafana.tar.gz').with_ensure('present') }
+      it { should contain_archive('/tmp/grafana.tar.gz').with_source(archive_source) }
+      it { should contain_archive('/tmp/grafana.tar.gz').with_extract_path(install_dir) }
     end
 
     describe 'create grafana user' do
@@ -164,7 +164,6 @@ describe 'grafana' do
     describe 'manage install_dir' do
       it { should contain_file(install_dir).with_ensure('directory') }
       it { should contain_file(install_dir).with_group('grafana').with_owner('grafana') }
-      it { should contain_file(install_dir).with_recurse(true).with_recurselimit(3) }
     end
 
     describe 'configure grafana' do


### PR DESCRIPTION
`puppet/archive` is the "official" archive module now, has [the best score (5.0 currently)](https://forge.puppetlabs.com/modules?utf-8=%E2%9C%93&sort=rank&q=archive) and [is actively developed](https://forge.puppetlabs.com/puppet/archive/changelog). So let's switch to it from `
camptocamp/archive`.

(Fixes https://github.com/bfraser/puppet-grafana/issues/81)