### PR TITLE
making it compliant with PE 2016.1.1 (#89)

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -74,12 +74,12 @@ class grafana (
   $install_method      = $::grafana::params::install_method,
   $manage_package_repo = $::grafana::params::manage_package_repo,
   $package_name        = $::grafana::params::package_name,
+  $rpm_iteration       = $::grafana::params::rpm_iteration,
   $package_source      = $::osfamily ? {
     /(RedHat|Amazon)/ => "https://grafanarel.s3.amazonaws.com/builds/grafana-${version}-${rpm_iteration}.x86_64.rpm",
     'Debian'          => "https://grafanarel.s3.amazonaws.com/builds/grafana_${version}_amd64.deb",
     default           => $archive_source,
   },
-  $rpm_iteration       = $::grafana::params::rpm_iteration,
   $service_name        = $::grafana::params::service_name,
   $version             = $::grafana::params::version,
 ) inherits grafana::params {


### PR DESCRIPTION
moved rpm_iteration parameter above package_source parameter.
Otherwise, I get the error
Error: Could not retrieve catalog from remote server: Error 400 on
SERVER: Evaluation Error: Error while evaluating a Resource Statement,
Evaluation Error: Error while evaluating a Function Call, default
expression for $package_source tries to illegally access not yet
evaluated $rpm_iteration

fixes #89
