### PR TITLE
rake validate currently errors with a Warning: License Indentifier Apache 2.0 is not in the SPDX list. message, adding a dash fixes this. adding extra gem to also validate the metadata.json file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+# 2.5.0 (2015-10-31)
+
+**Enhancements**
+- Support for [Grafana 2.5](http://grafana.org/blog/2015/10/28/Grafana-2-5-Released.html). This is just a version bump to reflect that Grafana 2.5 is now installed by default
+- [PR #58](https://github.com/bfraser/puppet-grafana/pull/58) Sort ```cfg``` keys so ```config.ini``` content is not updated every Puppet run
+
+**Fixes**
+- [Issue #52](https://github.com/bfraser/puppet-grafana/issues/52) Version logic moved to ```init.pp``` so overriding the version of Grafana to install works as intended
+
+**Behind The Scenes**
+
+- [PR #59](https://github.com/bfraser/puppet-grafana/pull/59) More specific version requirements in ```metadata.json``` due to use of ```contain``` function
+- [PR #61](https://github.com/bfraser/puppet-grafana/pull/61) Fixed typos in ```metadata.json```
+
 # 2.1.0 (2015-08-07)
 
 **Enhancements**

--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@ source "https://rubygems.org"
 group :test do
   gem "rake"
   gem "puppet", ENV['PUPPET_VERSION'] || '~> 3.6.0'
+  gem 'metadata-json-lint'
   gem "puppet-lint"
   gem "rspec-puppet", :git => 'https://github.com/rodjek/rspec-puppet.git'
   gem "puppet-syntax"

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "bfraser-grafana",
-  "version": "2.1.0",
+  "version": "2.5.0",
   "author": "bfraser",
   "summary": "This module provides Grafana, a dashboard and graph editor for Graphite and InfluxDB.",
   "license": "Apache 2.0",

--- a/metadata.json
+++ b/metadata.json
@@ -3,7 +3,7 @@
   "version": "2.5.0",
   "author": "bfraser",
   "summary": "This module provides Grafana, a dashboard and graph editor for Graphite and InfluxDB.",
-  "license": "Apache 2.0",
+  "license": "Apache-2.0",
   "source": "git://github.com/bfraser/puppet-grafana.git",
   "project_page": "https://github.com/bfraser/puppet-grafana",
   "issues_url": "https://github.com/bfraser/puppet-grafana/issues",


### PR DESCRIPTION
rake validate currently errors with a Warning: License Indentifier Apache 2.0 is not in the SPDX list. message, adding a dash fixes this. adding extra gem to also validate the metadata.json file