### PR TITLE
Adding extra gem to also validate the metadata.json file.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@ source "https://rubygems.org"
 group :test do
   gem "rake"
   gem "puppet", ENV['PUPPET_VERSION'] || '~> 3.6.0'
+  gem 'metadata-json-lint'
   gem "puppet-lint"
   gem "rspec-puppet", :git => 'https://github.com/rodjek/rspec-puppet.git'
   gem "puppet-syntax"

--- a/metadata.json
+++ b/metadata.json
@@ -3,7 +3,7 @@
   "version": "2.5.0",
   "author": "bfraser",
   "summary": "This module provides Grafana, a dashboard and graph editor for Graphite and InfluxDB.",
-  "license": "Apache 2.0",
+  "license": "Apache-2.0",
   "source": "https://github.com/bfraser/puppet-grafana.git",
   "project_page": "https://github.com/bfraser/puppet-grafana",
   "issues_url": "https://github.com/bfraser/puppet-grafana/issues",


### PR DESCRIPTION
Rake validate currently errors with a "Warning: License Indentifier Apache 2.0 is not in the SPDX list. message" .  Adding a dash to the license in metadata.json fixes this.

closes pull request #73 