### PR TITLE
Support HTTPS for Grafana resources

### DIFF
--- a/lib/puppet/provider/grafana.rb
+++ b/lib/puppet/provider/grafana.rb
@@ -78,7 +78,9 @@ class Puppet::Provider::Grafana < Puppet::Provider
             request.basic_auth resource[:grafana_user], resource[:grafana_password]
         end
 
-        return Net::HTTP.start(self.grafana_host, self.grafana_port) do |http|
+        return Net::HTTP.start(self.grafana_host, self.grafana_port,
+                               :use_ssl => self.grafana_scheme == 'https',
+                               :verify_mode => OpenSSL::SSL::VERIFY_NONE) do |http|
             http.request(request)
         end
     end


### PR DESCRIPTION
This change fixes the issue #86.