### PR TITLE
Fix the skeleton acceptance tests

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,6 +16,7 @@ group :development do
   gem "travis-lint"
   gem "beaker"
   gem "beaker-rspec"
+  gem "vagrant-wrapper"
   gem "puppet-blacksmith"
   gem "guard-rake"
 end

--- a/spec/acceptance/class_spec.rb
+++ b/spec/acceptance/class_spec.rb
@@ -6,7 +6,7 @@ describe 'grafana class' do
     # Using puppet_apply as a helper
     it 'should work idempotently with no errors' do
       pp = <<-EOS
-      class { 'grafana': }
+        class { 'grafana': }
       EOS
 
       # Run it twice and test for idempotency
@@ -18,7 +18,7 @@ describe 'grafana class' do
       it { should be_installed }
     end
 
-    describe service('grafana') do
+    describe service('grafana-server') do
       it { should be_enabled }
       it { should be_running }
     end

--- a/spec/acceptance/nodesets/centos-72-x64.yml
+++ b/spec/acceptance/nodesets/centos-72-x64.yml
@@ -1,0 +1,11 @@
+HOSTS:
+  centos-72-x64:
+    roles:
+      - master
+    platform: el-7-x86_64
+    box : puppetlabs/centos-7.2-64-nocm
+    box_url : https://atlas.hashicorp.com/puppetlabs/boxes/centos-7.2-64-nocm
+    hypervisor : vagrant
+CONFIG:
+  log_level: verbose
+  type: foss


### PR DESCRIPTION
This changes the service name of the skeleton acceptance tests so they
pass, the missing _vagrant-wrapper_ gem so the tests will run, and adds
a CentOS 7.2 nodeset.
