### PR TITLE
Added switch for RedHat 6/7 Repo Support

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -99,7 +99,7 @@ class grafana::install {
           if ( $::grafana::manage_package_repo ){
             yumrepo { 'grafana':
               descr    => 'grafana repo',
-              baseurl  => 'https://packagecloud.io/grafana/stable/el/6/$basearch',
+              baseurl  => 'https://packagecloud.io/grafana/stable/el/$::operatingsystemrelease/$basearch',
               gpgcheck => 1,
               gpgkey   => 'https://packagecloud.io/gpg.key https://grafanarel.s3.amazonaws.com/RPM-GPG-KEY-grafana',
               enabled  => 1,


### PR DESCRIPTION
Hi *,

we are using CentOS 7 and at the moment el/6/ is hard coded. Adding $::operatingsystemrelease fixes the issue for us.

Regards Lüder Thaele
