### PR TITLE
Fixed HTTPS call for EL6 default Ruby 1.8.7 version

### DIFF
--- a/lib/puppet/provider/grafana.rb
+++ b/lib/puppet/provider/grafana.rb
@@ -78,11 +78,12 @@ class Puppet::Provider::Grafana < Puppet::Provider
             request.basic_auth resource[:grafana_user], resource[:grafana_password]
         end
 
-        return Net::HTTP.start(self.grafana_host, self.grafana_port,
-                               :use_ssl => self.grafana_scheme == 'https',
-                               :verify_mode => OpenSSL::SSL::VERIFY_NONE) do |http|
-            http.request(request)
+        http_client = Net::HTTP.new(self.grafana_host, self.grafana_port)
+        if self.grafana_scheme == 'https'
+          http_client.use_ssl = true
+          http_client.verify_mode = OpenSSL::SSL::VERIFY_NONE
         end
+        return http_client.request(request)
     end
 end
 

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -18,7 +18,7 @@ class grafana::install {
       default           => $real_archive_source,
     }
   }
-  
+
   case $::grafana::install_method {
     'docker': {
       docker::image { 'grafana/grafana':


### PR DESCRIPTION
When trying to create a `grafana_datasource` using CentOS 6.8, the Puppet agent run failed with following error:
> `Could not evaluate: can't convert Hash into String`

Apparently this is caused by the way the `Net::HTTP` object is created, especially the HTTPS-related options. Fixed by creating the `Net::HTTP` object with only hostname/port params, and later adding the SSL options when using HTTPS.

