### PR TITLE
Upgrade packagecloud GPG key

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -78,7 +78,7 @@ class grafana::install {
               release  => 'wheezy',
               repos    => 'main',
               key      =>  {
-                'id'     => '418A7F2FB0E1E6E7EABF6FE8C2E73424D59097AB',
+                'id'     => '6A037BB52DF7D46D99DC59C101666247EBFF1218',
                 'source' => 'https://packagecloud.io/gpg.key'
               },
               before   => Package[$::grafana::package_name],


### PR DESCRIPTION
```
$> gpg --edit 0x01666247EBFF1218
gpg (GnuPG) 1.4.23; Copyright (C) 2015 Free Software Foundation, Inc.
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.

pub  4096R/0x01666247EBFF1218  created: 2018-12-10  expires: never       usage: SC
                               trust: unknown       validity: unknown
sub  4096R/0xAF7C6D1D513643CC  created: 2018-12-10  expires: never       usage: E
[ unknown] (1). packagecloud ops (production key) <ops@packagecloud.io>

gpg> fpr
pub   4096R/0x01666247EBFF1218 2018-12-10 packagecloud ops (production key) <ops@packagecloud.io>
 Primary key fingerprint: 6A03 7BB5 2DF7 D46D 99DC  59C1 0166 6247 EBFF 1218

```